### PR TITLE
Add Basic Functionality Test

### DIFF
--- a/cmd/test
+++ b/cmd/test
@@ -24,9 +24,9 @@ basic_help()
 {
     echo
     echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} basic [<options>]"
+    echo
     printf "    %-2s   %s\n" "" "Options:"
     printf "    %-3s   %s\n" "" "-w : Execute init without the --without-pull flag."
-    printf "    %-3s   %s\n" "" "-v : Execute down with the --volumes flag."
     printf "    %-3s   %s\n" "" "-h : Prints this help information."
     echo
 }
@@ -34,14 +34,10 @@ basic_help()
 basic() {
   # Parameters
   W=0
-  V=0
-  while getopts "wvh" opt; do
+  while getopts "wh" opt; do
     case $opt in
       w)
         W=1
-        ;;
-      v)
-        V=1
         ;;
       h)
         basic_help
@@ -61,22 +57,19 @@ basic() {
   echo "#######################"
   echo
 
-  if [ $V -eq 0 ]
-  then
-    echo "/adop compose down"
-    ${CONF_DIR}/adop compose down
-  else
-    echo "/adop compose down --volumes"
-    ${CONF_DIR}/adop compose down --volumes
-  fi
+  echo "...stopping LDOP if it is already running..."
+  echo "/adop compose down"
+  ${CONF_DIR}/adop compose down
 
+  echo "...starting LDOP with temporary volumes..."
   if [ $W -eq 0 ]
   then  
     echo "/adop compose init --without-load --without-pull"
-    ${CONF_DIR}/adop compose init --without-load --without-pull
+    ${CONF_DIR}/adop compose -v test_local init --without-load --without-pull
   else
+    echo "...-w flag specified; omitting without-pull..."
     echo "/adop compose init --without-load"
-    ${CONF_DIR}/adop compose init --without-load
+    ${CONF_DIR}/adop compose -v test_local init --without-load
   fi
   
   # Sources to obtain the password for Jenkins
@@ -136,6 +129,16 @@ basic() {
   echo "#  Testing Complete   #"
   echo "#######################"
   echo
+  
+  STATS1=$(docker ps -f "status=created" --format "{{.Names}}: {{.Status}}")
+  STATS2=$(docker ps -f "status=restarting" --format "{{.Names}}: {{.Status}}")
+  STATS3=$(docker ps -f "status=removing" --format "{{.Names}}: {{.Status}}")
+  STATS4=$(docker ps -f "status=paused" --format "{{.Names}}: {{.Status}}")
+  STATS5=$(docker ps -f "status=exited" --format "{{.Names}}: {{.Status}}")
+  STATS6=$(docker ps -f "status=dead" --format "{{.Names}}: {{.Status}}")
+
+  echo "...stopping the test and removing volumes..."
+  ${CONF_DIR}/adop compose -v test_local down --volumes
 
   echo
   echo "#######################"
@@ -147,12 +150,13 @@ basic() {
   echo "Load_Platform Build Result: $RESULT"
   echo
   echo "Docker Containers with Non-running Statuses:"
-  docker ps -f "status=created" --format "{{.Names}}: {{.Status}}"
-  docker ps -f "status=restarting" --format "{{.Names}}: {{.Status}}"
-  docker ps -f "status=removing" --format "{{.Names}}: {{.Status}}"
-  docker ps -f "status=paused" --format "{{.Names}}: {{.Status}}"
-  docker ps -f "status=exited" --format "{{.Names}}: {{.Status}}"
-  docker ps -f "status=dead" --format "{{.Names}}: {{.Status}}"
+  echo $STATS1
+  echo $STATS2
+  echo $STATS3
+  echo $STATS4
+  echo $STATS5
+  echo $STATS6
+  echo "...basic test complete."
   echo
 }
 

--- a/cmd/test
+++ b/cmd/test
@@ -14,23 +14,25 @@ help() {
     cmd_usage
     echo
     echo "Available subcommands are:"
-    printf "    %-20s   %s\n" "down" "Test that \"LDOP compose down\" is working properly."
-    printf "    %-20s   %s\n" "up" "Test that \"LDOP compose up\" is working properly."
-    printf "    %-20s   %s\n" "all" "Run all tests."
+    printf "    %-20s   %s\n" "clean" "Test functionality given a clean environment."
     printf "    %-20s   %s\n" "help" "Prints this help information"
     echo
 }
 
-down() {
-  echo "testing down"
-}
-
-up() {
-  echo "testing up"
-}
-
-all() {
-  echo "running all tests"
+clean() {
+  echo
+  echo "#######################"
+  echo "# Testing in Progress #"
+  echo "#######################"
+  echo
+  sleep 1
+  ./cmd/compose down --volumes
+  ./cmd/compose init --without-load --without-pull
+  echo
+  echo "#######################"
+  echo "#  Testing Complete   #"
+  echo "#######################"
+  echo
 }
 
 shift $(($OPTIND -1))
@@ -46,14 +48,8 @@ if [ ! -z ${SUBCOMMAND_OPT} ]; then
     "cmd_desc"|"help")
         ${SUBCOMMAND_OPT}
         ;;
-    "all")
-        all
-        ;;
-    "down")
-        down
-        ;;
-    "up")
-        up
+    "clean")
+        clean
         ;;
     *)
         echo "Invalid subcommand."

--- a/cmd/test
+++ b/cmd/test
@@ -90,6 +90,24 @@ basic() {
   echo "#  Testing Complete   #"
   echo "#######################"
   echo
+
+  echo
+  echo "#######################"
+  echo "#  Testing Results:   #"
+  echo "#######################"
+  echo
+
+  echo
+  echo "Load_Platform Build Result: $RESULT"
+  echo
+  echo "Docker Containers with Non-running Statuses:"
+  docker ps -f "status=created" --format "{{.Names}}: {{.Status}}"
+  docker ps -f "status=restarting" --format "{{.Names}}: {{.Status}}"
+  docker ps -f "status=removing" --format "{{.Names}}: {{.Status}}"
+  docker ps -f "status=paused" --format "{{.Names}}: {{.Status}}"
+  docker ps -f "status=exited" --format "{{.Names}}: {{.Status}}"
+  docker ps -f "status=dead" --format "{{.Names}}: {{.Status}}"
+  echo
 }
 
 shift $(($OPTIND -1))

--- a/cmd/test
+++ b/cmd/test
@@ -56,17 +56,26 @@ basic() {
     esac
   done
 
+  echo "...checking if LDOP is currently running..."
+  PS=$(${CONF_DIR}/adop compose ps -q | wc -l)
+
   if [ $F -eq 0 ]
   then
-    echo "This test involves running /adop compose down"
-    read -p "Proceed to shut down running containers? (Y/N)   " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]
+    if [ $PS -gt 4 ]
     then
-      echo "...proceeding..."
-    else
-      echo "Exiting."
-      exit 0
+      echo "This test involves running /adop compose down"
+      read -p "Proceed to shut down running containers? (Y/N)   " -n 1 -r
+      echo
+      if [[ $REPLY =~ ^[Yy]$ ]]
+      then
+        echo "...proceeding..."
+        echo "...stopping LDOP..."
+        echo "/adop compose down"
+        ${CONF_DIR}/adop compose down
+      else
+        echo "Exiting."
+        exit 0
+      fi
     fi
   fi
 
@@ -75,10 +84,6 @@ basic() {
   echo "# Testing in Progress #"
   echo "#######################"
   echo
-
-  echo "...stopping LDOP if it is already running..."
-  echo "/adop compose down"
-  ${CONF_DIR}/adop compose down
 
   echo "...starting LDOP with temporary volumes..."
   if [ $W -eq 0 ]

--- a/cmd/test
+++ b/cmd/test
@@ -153,13 +153,14 @@ basic() {
   echo "#  Testing Complete   #"
   echo "#######################"
   echo
-  
-  STATS1=$(docker ps -f "status=created" --format "{{.Names}}: {{.Status}}")
-  STATS2=$(docker ps -f "status=restarting" --format "{{.Names}}: {{.Status}}")
-  STATS3=$(docker ps -f "status=removing" --format "{{.Names}}: {{.Status}}")
-  STATS4=$(docker ps -f "status=paused" --format "{{.Names}}: {{.Status}}")
-  STATS5=$(docker ps -f "status=exited" --format "{{.Names}}: {{.Status}}")
-  STATS6=$(docker ps -f "status=dead" --format "{{.Names}}: {{.Status}}")
+
+  # Assign array indices for each non-running status
+  STATS[1]=$(docker ps -f "status=created" --format "{{.Names}}: {{.Status}}")
+  STATS[2]=$(docker ps -f "status=restarting" --format "{{.Names}}: {{.Status}}")
+  STATS[3]=$(docker ps -f "status=removing" --format "{{.Names}}: {{.Status}}")
+  STATS[4]=$(docker ps -f "status=paused" --format "{{.Names}}: {{.Status}}")
+  STATS[5]=$(docker ps -f "status=exited" --format "{{.Names}}: {{.Status}}")
+  STATS[6]=$(docker ps -f "status=dead" --format "{{.Names}}: {{.Status}}")
 
   echo "...stopping the test and removing volumes..."
   ${CONF_DIR}/adop compose -v test_local down --volumes
@@ -174,12 +175,20 @@ basic() {
   echo "Load_Platform Build Result: $RESULT"
   echo
   echo "Docker Containers with Non-running Statuses:"
-  echo $STATS1
-  echo $STATS2
-  echo $STATS3
-  echo $STATS4
-  echo $STATS5
-  echo $STATS6
+  # Iterate over the 6 array elements
+  for i in `seq 1 6`
+  do
+    # Store the array element in item
+    item=${STATS[$i]}
+    # If the element contains more than 0 characters...
+    # This is necessary as the docker ps command returns successful even
+    # with no output. That would print a blank line.
+    if [ "${#item}" -gt "0" ]
+    then
+      # Print the non-running statuses...
+      echo ${STATS[$i]}
+    fi
+  done
   echo "...basic test complete."
   echo
 }

--- a/cmd/test
+++ b/cmd/test
@@ -51,6 +51,17 @@ basic() {
     esac
   done
 
+  echo "This test involves running /adop compose down"
+  read -p "Proceed to shut down running containers? (Y/N)   " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]
+  then
+    echo "...proceeding..."
+  else
+    echo "Exiting."
+    exit 0
+  fi
+
   echo
   echo "#######################"
   echo "# Testing in Progress #"

--- a/cmd/test
+++ b/cmd/test
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 SUB_CMD_NAME="test"
 
@@ -11,8 +11,7 @@ cmd_usage() {
 }
 
 help() {
-    cmd_usage
-    echo
+    cmd_usage echo
     echo "Available subcommands are:"
     printf "    %-20s   %s\n" "clean" "Test functionality given a clean environment."
     printf "    %-20s   %s\n" "help" "Prints this help information"
@@ -28,26 +27,54 @@ clean() {
   sleep 1
 
   #./cmd/compose down --volumes
-  #./cmd/compose init --without-load --without-pull
+  #./cmd/compose init --without-pull
 
-  JOB_URL=localhost/jenkins/job/Load_Platform
+  # The URL of the job Load_Platform as hit from within the Jenkins container
+  JOB_URL=localhost:8080/jenkins/job/Load_Platform
+
+  # A value to determine if the job is currently executing
   GREP_RETURN_CODE=0
 
+  # Sources to obtain the password for Jenkins
   source ${CONF_DIR}/conf/env.provider.sh
   source ${CONF_DIR}/credentials.generate.sh
-  source ${CONF_DIR}/env.config.sh
+  source ${CONF_DIR}/env.config.sh 
 
-  # Start the build
-  curl -s --data '' jenkins:${PASSWORD_JENKINS}@$JOB_URL/buildWithParameters
+  # Trigger the parameterized job with default parameters.
+  # -s silent, don't output curl details
+  # docker exec jenkins, execute from within jenkins container
+  # --data '', execute the curl as a POST
+  # /buildWithParameters, build with default parameters
+  docker exec jenkins curl -s --data '' jenkins:${PASSWORD_JENKINS}@${JOB_URL}/buildWithParameters
+  echo "...triggered the job Load_Platform to build with default parameters..."
 
-  # Poll every thirty seconds until the build is finished
+  # Disable -e as set in ADOP...
+  set +e
+
+  # ...while the successful curl of the lastBuild information
+  # holds a null value as the result...
+  # "while the job is still executing"
   while [ $GREP_RETURN_CODE -eq 0 ]
   do
-    sleep 15
-    # Grep will return 0 while the build is running:
-    curl -s jenkins:${PASSWORD_JENKINS}@$JOB_URL/lastBuild/api/python?pretty=true | grep -n "result\" : None"
-    GREP_RETURN_CODE=$?
+    # Give the job time to build, check every 30 seconds
+    echo "...waiting 30 seconds for Load_Platform job to execute..."
+    sleep 30
+    CURL=$(docker exec jenkins curl -s jenkins:${PASSWORD_JENKINS}@${JOB_URL}/lastBuild/api/json)
+    # If the curl command did not error...
+    # (only update the "job currently executing" variable if the curl succeeds)
+    if [ $? -eq 0 ]
+    then
+      # Grep will return 0 (successfully obtained null result) 
+      # while the build is running
+      echo $CURL | grep result\":null > /dev/null
+      GREP_RETURN_CODE=$?
+    fi
+    # If the curl command errored, sleep and try again
   done
+  RESULT=$(echo $CURL | grep -E -o "result\":.{0,10}" | awk -F'"' '{print $3}')
+  echo "...Load_Platform job completed! Build Status: $RESULT"
+
+  set -e
 
   echo
   echo "#######################"

--- a/cmd/test
+++ b/cmd/test
@@ -25,7 +25,8 @@ basic_help()
     echo
     echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} basic [<options>]"
     printf "    %-2s   %s\n" "" "Options:"
-    printf "    %-3s   %s\n" "" "-w : Execute init with the --without-pull flag."
+    printf "    %-3s   %s\n" "" "-w : Execute init without the --without-pull flag."
+    printf "    %-3s   %s\n" "" "-v : Execute down with the --volumes flag."
     printf "    %-3s   %s\n" "" "-h : Prints this help information."
     echo
 }
@@ -33,10 +34,14 @@ basic_help()
 basic() {
   # Parameters
   W=0
-  while getopts "wh" opt; do
+  V=0
+  while getopts "wvh" opt; do
     case $opt in
       w)
         W=1
+        ;;
+      v)
+        V=1
         ;;
       h)
         basic_help
@@ -49,23 +54,29 @@ basic() {
         ;;
     esac
   done
-  
+
   echo
   echo "#######################"
   echo "# Testing in Progress #"
   echo "#######################"
   echo
- 
-  echo "/adop compose down --volumes"
-  ${CONF_DIR}/adop compose down --volumes
+
+  if [ $V -eq 0 ]
+  then
+    echo "/adop compose down"
+    ${CONF_DIR}/adop compose down
+  else
+    echo "/adop compose down --volumes"
+    ${CONF_DIR}/adop compose down --volumes
+  fi
 
   if [ $W -eq 0 ]
   then  
-    echo "/adop compose init --without-load"
-    ${CONF_DIR}/adop compose init --without-load
-  else
     echo "/adop compose init --without-load --without-pull"
     ${CONF_DIR}/adop compose init --without-load --without-pull
+  else
+    echo "/adop compose init --without-load"
+    ${CONF_DIR}/adop compose init --without-load
   fi
   
   # Sources to obtain the password for Jenkins

--- a/cmd/test
+++ b/cmd/test
@@ -73,8 +73,29 @@ basic() {
       if [[ $REPLY =~ ^[Yy]$ ]]
       then
         echo "...proceeding..."
+				echo "...checking which containers are unpaused..."
+				PAUSED_CONTAINERS=$(./adop compose ps 2>/dev/null | grep Paused | \
+					awk -F'[[:space:]]' '{print $1}')
+				if [ "${#PAUSED_CONTAINERS}" -gt "0" ]
+				then
+					COUNT=$(wc -w <<< $PAUSED_CONTAINERS | tr -d '[:space:]')
+					echo "#############################################"
+					echo "There are $COUNT containers paused."
+					echo "The following containers are paused..."
+					echo $PAUSED_CONTAINERS
+					echo "#############################################"
+					for i in $PAUSED_CONTAINERS
+					do
+						echo "...unpausing $i..."
+						${CONF_DIR}/adop compose unpause $i
+					done
+					echo "#############################################"
+					echo "All containers are now unpaused."
+					echo "#############################################"
+				else
+					echo "There are no containers paused."
+				fi
         echo "...stopping LDOP..."
-        ${CONF_DIR}/adop compose unpause 2>/dev/null
         ${CONF_DIR}/adop compose down 2>/dev/null
       else
         echo "Exiting."

--- a/cmd/test
+++ b/cmd/test
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+
+SUB_CMD_NAME="test"
+
+cmd_desc() {
+    echo "For confirming LDOP functionality during development."
+}
+
+cmd_usage() {
+    echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} <subcommand>"
+}
+
+help() {
+    cmd_usage
+    echo
+    echo "Available subcommands are:"
+    printf "    %-20s   %s\n" "down" "Test that \"LDOP compose down\" is working properly."
+    printf "    %-20s   %s\n" "up" "Test that \"LDOP compose up\" is working properly."
+    printf "    %-20s   %s\n" "all" "Run all tests."
+    printf "    %-20s   %s\n" "help" "Prints this help information"
+    echo
+}
+
+down() {
+  echo "testing down"
+}
+
+up() {
+  echo "testing up"
+}
+
+all() {
+  echo "running all tests"
+}
+
+shift $(($OPTIND -1))
+SUBCOMMAND_OPT="${1:-help}"
+
+# Only shift if there are other parameters
+if [ $# -ge 1 ]; then
+    shift
+fi
+
+if [ ! -z ${SUBCOMMAND_OPT} ]; then
+  case ${SUBCOMMAND_OPT} in
+    "cmd_desc"|"help")
+        ${SUBCOMMAND_OPT}
+        ;;
+    "all")
+        all
+        ;;
+    "down")
+        down
+        ;;
+    "up")
+        up
+        ;;
+    *)
+        echo "Invalid subcommand."
+        help
+        exit 1
+        ;;
+  esac
+fi

--- a/cmd/test
+++ b/cmd/test
@@ -27,6 +27,7 @@ basic_help()
     echo
     printf "    %-2s   %s\n" "" "Options:"
     printf "    %-3s   %s\n" "" "-w : Execute init without the --without-pull flag."
+    printf "    %-3s   %s\n" "" "-f : Force; do not prompt for confirmation."
     printf "    %-3s   %s\n" "" "-h : Prints this help information."
     echo
 }
@@ -34,10 +35,14 @@ basic_help()
 basic() {
   # Parameters
   W=0
-  while getopts "wh" opt; do
+  F=0
+  while getopts "wfh" opt; do
     case $opt in
       w)
         W=1
+        ;;
+      f)
+        F=1
         ;;
       h)
         basic_help
@@ -51,15 +56,18 @@ basic() {
     esac
   done
 
-  echo "This test involves running /adop compose down"
-  read -p "Proceed to shut down running containers? (Y/N)   " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]
+  if [ $F -eq 0 ]
   then
-    echo "...proceeding..."
-  else
-    echo "Exiting."
-    exit 0
+    echo "This test involves running /adop compose down"
+    read -p "Proceed to shut down running containers? (Y/N)   " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+      echo "...proceeding..."
+    else
+      echo "Exiting."
+      exit 0
+    fi
   fi
 
   echo

--- a/cmd/test
+++ b/cmd/test
@@ -26,7 +26,7 @@ basic_help()
     echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} basic [<options>]"
     echo
     printf "    %-2s   %s\n" "" "Options:"
-    printf "    %-3s   %s\n" "" "-w : Execute init without the --without-pull flag."
+    printf "    %-3s   %s\n" "" "-w : Execute init --with-pull."
     printf "    %-3s   %s\n" "" "-f : Force; do not prompt for confirmation."
     printf "    %-3s   %s\n" "" "-h : Prints this help information."
     echo

--- a/cmd/test
+++ b/cmd/test
@@ -57,11 +57,15 @@ basic() {
   done
 
   echo "...checking if LDOP is currently running..."
-  PS=$(${CONF_DIR}/adop compose ps -q | wc -l)
+  PS=$(${CONF_DIR}/adop compose ps 2>/dev/null)
+
+  # Get all the output after the last occurance of *-\s
+  AFTER_HEADER=${PS##*----}
 
   if [ $F -eq 0 ]
   then
-    if [ $PS -gt 4 ]
+    # If there are any items in /adop compose ps...
+    if [ "${#AFTER_HEADER}" -gt "0" ] 
     then
       echo "This test involves running /adop compose down"
       read -p "Proceed to shut down running containers? (Y/N)   " -n 1 -r

--- a/cmd/test
+++ b/cmd/test
@@ -73,30 +73,30 @@ basic() {
       if [[ $REPLY =~ ^[Yy]$ ]]
       then
         echo "...proceeding..."
-				echo "...checking which containers are unpaused..."
-				PAUSED_CONTAINERS=$(./adop compose ps 2>/dev/null | grep Paused | \
-					awk -F'[[:space:]]' '{print $1}')
-				if [ "${#PAUSED_CONTAINERS}" -gt "0" ]
-				then
-					COUNT=$(wc -w <<< $PAUSED_CONTAINERS | tr -d '[:space:]')
-					echo "#############################################"
-					echo "There are $COUNT containers paused."
-					echo "The following containers are paused..."
-					echo $PAUSED_CONTAINERS
-					echo "#############################################"
-					for i in $PAUSED_CONTAINERS
-					do
-						echo "...unpausing $i..."
-						${CONF_DIR}/adop compose unpause $i
-					done
-					echo "#############################################"
-					echo "All containers are now unpaused."
-					echo "#############################################"
-				else
-					echo "There are no containers paused."
-				fi
+        echo "...checking which containers are unpaused..."
+        PAUSED_CONTAINERS=$(./adop compose ps 2>/dev/null | grep Paused | \
+        awk -F'[[:space:]]' '{print $1}')
+        if [ "${#PAUSED_CONTAINERS}" -gt "0" ]
+        then
+          COUNT=$(wc -w <<< $PAUSED_CONTAINERS | tr -d '[:space:]')
+          echo "#############################################"
+          echo "There are $COUNT containers paused."
+          echo "The following containers are paused..."
+          echo $PAUSED_CONTAINERS
+          echo "#############################################"
+          for i in $PAUSED_CONTAINERS
+          do
+            echo "...unpausing $i..."
+            ${CONF_DIR}/adop compose unpause $i
+          done
+          echo "#############################################"
+          echo "All containers are now unpaused."
+          echo "#############################################"
+        else
+          echo "There are no containers paused."
+        fi
         echo "...stopping LDOP..."
-        ${CONF_DIR}/adop compose down 2>/dev/null
+        ${CONF_DIR}/adop compose down
       else
         echo "Exiting."
         exit 0

--- a/cmd/test
+++ b/cmd/test
@@ -26,8 +26,29 @@ clean() {
   echo "#######################"
   echo
   sleep 1
-  ./cmd/compose down --volumes
-  ./cmd/compose init --without-load --without-pull
+
+  #./cmd/compose down --volumes
+  #./cmd/compose init --without-load --without-pull
+
+  JOB_URL=localhost/jenkins/job/Load_Platform
+  GREP_RETURN_CODE=0
+
+  source ${CONF_DIR}/conf/env.provider.sh
+  source ${CONF_DIR}/credentials.generate.sh
+  source ${CONF_DIR}/env.config.sh
+
+  # Start the build
+  curl -s --data '' jenkins:${PASSWORD_JENKINS}@$JOB_URL/buildWithParameters
+
+  # Poll every thirty seconds until the build is finished
+  while [ $GREP_RETURN_CODE -eq 0 ]
+  do
+    sleep 15
+    # Grep will return 0 while the build is running:
+    curl -s jenkins:${PASSWORD_JENKINS}@$JOB_URL/lastBuild/api/python?pretty=true | grep -n "result\" : None"
+    GREP_RETURN_CODE=$?
+  done
+
   echo
   echo "#######################"
   echo "#  Testing Complete   #"

--- a/cmd/test
+++ b/cmd/test
@@ -20,7 +20,37 @@ help() {
     echo
 }
 
+basic_help() 
+{
+    echo
+    echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} basic [<options>]"
+    printf "    %-2s   %s\n" "" "Options:"
+    printf "    %-3s   %s\n" "" "-w : Execute init with the --without-pull flag."
+    printf "    %-3s   %s\n" "" "-h : Prints this help information."
+    echo
+}
+
 basic() {
+  # Parameters
+  W=0
+  while getopts "wh" opt; do
+    case $opt in
+      w)
+        W=1
+        ;;
+      h)
+        basic_help
+        exit 0
+        ;;
+      *)
+        echo "Invalid parameter(s) or option(s)."
+        basic_help
+        exit 1
+        ;;
+    esac
+  done
+  echo "W: "$W
+  exit
   echo
   echo "#######################"
   echo "# Testing in Progress #"
@@ -121,10 +151,10 @@ fi
 if [ ! -z ${SUBCOMMAND_OPT} ]; then
   case ${SUBCOMMAND_OPT} in
     "cmd_desc"|"help")
-        ${SUBCOMMAND_OPT}
+        ${SUBCOMMAND_OPT} "$@"
         ;;
     "basic")
-        basic
+        basic "$@"
         ;;
     *)
         echo "Invalid subcommand."

--- a/cmd/test
+++ b/cmd/test
@@ -67,15 +67,15 @@ basic() {
     # If there are any items in /adop compose ps...
     if [ "${#AFTER_HEADER}" -gt "0" ] 
     then
-      echo "This test involves running /adop compose down"
-      read -p "Proceed to shut down running containers? (Y/N)   " -n 1 -r
+      echo "This test will unpause any paused LDOP containers and shut them down."
+      read -p "Proceed to shut down running and paused containers? (Y/N)   " -n 1 -r
       echo
       if [[ $REPLY =~ ^[Yy]$ ]]
       then
         echo "...proceeding..."
         echo "...stopping LDOP..."
-        echo "/adop compose down"
-        ${CONF_DIR}/adop compose down
+        ${CONF_DIR}/adop compose unpause 2>/dev/null
+        ${CONF_DIR}/adop compose down 2>/dev/null
       else
         echo "Exiting."
         exit 0

--- a/cmd/test
+++ b/cmd/test
@@ -49,8 +49,7 @@ basic() {
         ;;
     esac
   done
-  echo "W: "$W
-  exit
+  
   echo
   echo "#######################"
   echo "# Testing in Progress #"
@@ -59,10 +58,16 @@ basic() {
  
   echo "/adop compose down --volumes"
   ${CONF_DIR}/adop compose down --volumes
-  
-  echo "/adop compose init --without-pull"
-  ${CONF_DIR}/adop compose init --without-load
 
+  if [ $W -eq 0 ]
+  then  
+    echo "/adop compose init --without-load"
+    ${CONF_DIR}/adop compose init --without-load
+  else
+    echo "/adop compose init --without-load --without-pull"
+    ${CONF_DIR}/adop compose init --without-load --without-pull
+  fi
+  
   # Sources to obtain the password for Jenkins
   source ${CONF_DIR}/conf/env.provider.sh
   source ${CONF_DIR}/credentials.generate.sh

--- a/cmd/test
+++ b/cmd/test
@@ -11,34 +11,41 @@ cmd_usage() {
 }
 
 help() {
+    echo
     cmd_usage echo
+    echo
     echo "Available subcommands are:"
-    printf "    %-20s   %s\n" "clean" "Test functionality given a clean environment."
+    printf "    %-20s   %s\n" "basic" "Test basic functionality."
     printf "    %-20s   %s\n" "help" "Prints this help information"
     echo
 }
 
-clean() {
+basic() {
   echo
   echo "#######################"
   echo "# Testing in Progress #"
   echo "#######################"
   echo
-  sleep 1
+ 
+  echo "/adop compose down --volumes"
+  ${CONF_DIR}/adop compose down --volumes
+  
+  echo "/adop compose init --without-pull"
+  ${CONF_DIR}/adop compose init --without-load
 
-  #./cmd/compose down --volumes
-  #./cmd/compose init --without-pull
+  # Sources to obtain the password for Jenkins
+  source ${CONF_DIR}/conf/env.provider.sh
+  source ${CONF_DIR}/credentials.generate.sh
+  source ${CONF_DIR}/env.config.sh 
+
+  ############### Test if Load_Platform job works properly ###############
+  echo "Testing if Load_Platform job is successful..."
 
   # The URL of the job Load_Platform as hit from within the Jenkins container
   JOB_URL=localhost:8080/jenkins/job/Load_Platform
 
   # A value to determine if the job is currently executing
   GREP_RETURN_CODE=0
-
-  # Sources to obtain the password for Jenkins
-  source ${CONF_DIR}/conf/env.provider.sh
-  source ${CONF_DIR}/credentials.generate.sh
-  source ${CONF_DIR}/env.config.sh 
 
   # Trigger the parameterized job with default parameters.
   # -s silent, don't output curl details
@@ -66,7 +73,7 @@ clean() {
     then
       # Grep will return 0 (successfully obtained null result) 
       # while the build is running
-      echo $CURL | grep result\":null > /dev/null
+      echo $CURL | grep building\":true > /dev/null
       GREP_RETURN_CODE=$?
     fi
     # If the curl command errored, sleep and try again
@@ -75,6 +82,8 @@ clean() {
   echo "...Load_Platform job completed! Build Status: $RESULT"
 
   set -e
+  
+  ############### Tested if Load_Platform job works properly ###############
 
   echo
   echo "#######################"
@@ -96,8 +105,8 @@ if [ ! -z ${SUBCOMMAND_OPT} ]; then
     "cmd_desc"|"help")
         ${SUBCOMMAND_OPT}
         ;;
-    "clean")
-        clean
+    "basic")
+        basic
         ;;
     *)
         echo "Invalid subcommand."

--- a/etc/volumes/test_local/default.yml
+++ b/etc/volumes/test_local/default.yml
@@ -1,0 +1,102 @@
+version: '3'
+
+volumes: 
+  test_elasticsearch_data:
+  test_nginx_config:
+  test_nginx_releasenote:
+  test_ldap_db:
+  test_ldap_static:
+  test_gerrit_mysql_data:
+  test_git_repos:
+  test_gerrit_review_site:
+  test_sensu_api_conf:
+  test_sensu_server_conf:
+  test_sensu_client_conf:
+  test_sensu_rabbitmq_data:
+  test_sensu_redis_data:
+  test_sonar_mysql_data:
+  test_sonar_data:
+  test_sonar_extensions:
+  test_sonar_logs:
+  test_jenkins_slave_home:
+  test_jenkins_home:
+  test_jenkins_home:
+  test_nexus_sonatype_work:
+  test_registry_certs:
+  test_registry_data:
+
+services:
+  elasticsearch:
+    volumes:
+      - test_elasticsearch_data:/usr/share/elasticsearch/data
+
+  proxy:
+    volumes:
+      - test_nginx_config:/etc/nginx
+      - test_nginx_releasenote:/usr/share/nginx/html
+
+  ldap:
+    volumes:
+        - test_ldap_db:/var/lib/ldap
+        - test_ldap_static:/etc/ldap
+
+  gerrit-mysql:
+    volumes:
+      - test_gerrit_mysql_data:/var/lib/mysql
+
+  gerrit:
+    user: root
+    volumes:
+      - test_git_repos:/var/git/repos 
+      - test_gerrit_review_site:/var/gerrit/review_site 
+
+  sensu-api:
+    volumes:
+      - test_sensu_api_conf:/etc/sensu/conf.d
+
+  sensu-server:
+    volumes:
+      - test_sensu_server_conf:/etc/sensu/conf.d
+
+  sensu-client:
+    volumes:
+      - test_sensu_client_conf:/etc/sensu/conf.d
+
+  sensu-rabbitmq:
+    volumes:
+      - test_sensu_rabbitmq_data:/var/lib/rabbitmq
+
+  sensu-redis:
+    volumes:
+      - test_sensu_redis_data:/data
+
+  sonar-mysql:
+    volumes:
+      - test_sonar_mysql_data:/var/lib/mysql 
+
+  sonar:
+    volumes:
+      - test_sonar_data:/opt/sonarqube/data
+      - test_sonar_extensions:/opt/sonarqube/extensions 
+      - test_sonar_logs:/opt/sonarqube/logs
+
+  jenkins-slave:
+    volumes:
+      - test_jenkins_slave_home:/workspace
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  jenkins:
+    user: root 
+    volumes:
+      - test_jenkins_home:/var/jenkins_home 
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  nexus:
+    volumes:
+      - test_nexus_sonatype_work:/sonatype-work
+
+  registry:
+    volumes:
+      - test_registry_certs:/certs
+      - test_registry_data:/data
+


### PR DESCRIPTION
Implemented `/adop test basic`:
  - runs `/adop compose down --volumes`
  - runs `/adop compose init --without-load`
  - triggers `Load_Platform` job to run
  - checks the states of containers that are not running
  - outputs the results (Load_Platform build result, container names and statuses that are not running)

Example Output from `/adop test basic`:
```
#######################
#  Testing Results:   #
#######################


Load_Platform Build Result: SUCCESS

Docker Containers with Non-running Statuses:
registry: Restarting (1) About a minute ago

```
