### PR TITLE
LDOP-57 integration test infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ env.override.sh
 conf/provider/env.provider.*.sh
 *.seq
 .adop*
+
+# Terraform integration test
+terraform.tfstate
+terraform.tfstate.backup
+terraform.key
+terraform.key.pub

--- a/test/integration/ldop-integration.tf
+++ b/test/integration/ldop-integration.tf
@@ -95,7 +95,7 @@ resource "aws_instance" "test_env" {
       "cd ~/ldop-docker-compose",
       "echo 'test\n' | sudo ./adop compose init",
       "./adop compose down --volumes",
-      "./adop test -f basic",
+      "./adop test basic -f",
     ]
   }
 }

--- a/test/integration/ldop-integration.tf
+++ b/test/integration/ldop-integration.tf
@@ -1,0 +1,108 @@
+# Providers
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+# Resources
+
+resource "aws_security_group" "test_env" {
+  name = "terraform_test_env"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # outbound internet access
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_key_pair" "test_key" {
+  key_name = "terraform-ldop"
+  public_key = "${file("${path.module}/terraform.key.pub")}"
+}
+
+resource "aws_instance" "test_env" {
+  instance_type          = "t2.large"
+  key_name               = "${aws_key_pair.test_key.key_name}"
+  ami                    = "ami-6df1e514"
+  vpc_security_group_ids = ["${aws_security_group.test_env.id}"]
+
+  root_block_device {
+    volume_size = 16
+  }
+
+  # Install docker, docker-compose and git
+  provisioner "remote-exec" {
+    connection {
+      user        = "ec2-user"
+      private_key = "${file("${path.module}/terraform.key")}"
+    }
+
+    inline = [
+      "sudo yum update -y",
+      "sudo yum install -y docker",
+      "sudo service docker start",
+      "sudo usermod -aG docker ec2-user",
+      "sudo pip install docker-compose && sudo cp /usr/local/bin/docker-compose /usr/bin/",
+      "sudo yum install -y git",
+    ]
+  }
+
+  # Clone ldop-docker-compose repo 
+  provisioner "remote-exec" {
+    connection {
+      user        = "ec2-user"
+      private_key = "${file("${path.module}/terraform.key")}"
+    }
+
+    inline = [
+      "git clone https://github.com/liatrio/ldop-docker-compose.git",
+    ]
+  }
+
+  # Copy new docker-compose file
+  provisioner "file" {
+    connection {
+      user        = "ec2-user"
+      private_key = "${file("${path.module}/terraform.key")}"
+    }
+
+    source      = "${path.module}/docker-compose.yml"
+    destination = "~/ldop-docker-compose/docker-compose.yml"
+  }
+
+  # Copy test secrets file
+  provisioner "file" {
+    connection {
+      user        = "ec2-user"
+      private_key = "${file("${path.module}/terraform.key")}"
+    }
+
+    source      = "${path.module}/platform.secrets.sh"
+    destination = "~/ldop-docker-compose/platform.secrets.sh"
+  }
+
+  # Run integration test
+  provisioner "remote-exec" {
+    connection {
+      user        = "ec2-user"
+      private_key = "${file("${path.module}/terraform.key")}"
+    }
+
+    inline = [
+      "cd ~/ldop-docker-compose",
+      "sudo ./adop compose init", # Also creates certs
+      "./adop compose down --volumes",
+      "./adop test basic",
+    ]
+  }
+}

--- a/test/integration/ldop-integration.tf
+++ b/test/integration/ldop-integration.tf
@@ -95,7 +95,7 @@ resource "aws_instance" "test_env" {
       "cd ~/ldop-docker-compose",
       "echo 'test\n' | sudo ./adop compose init",
       "./adop compose down --volumes",
-      "./adop test basic",
+      "./adop test -f basic",
     ]
   }
 }

--- a/test/integration/ldop-integration.tf
+++ b/test/integration/ldop-integration.tf
@@ -2,6 +2,10 @@ provider "aws" {
   region = "us-west-2"
 }
 
+variable "branch_name" {
+  default = "master"
+}
+
 resource "random_id" "test" {
   byte_length = 4
 }
@@ -70,6 +74,7 @@ resource "aws_instance" "test_env" {
 
     inline = [
       "git clone https://github.com/liatrio/ldop-docker-compose.git",
+      "git -C ./ldop-docker-compose checkout ${var.branch_name}",
     ]
   }
 

--- a/test/integration/run-integration-test.sh
+++ b/test/integration/run-integration-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash +e
+
+script_dir=$(dirname $0)
+
+# Generate test ssh key
+rm -f $script_dir/terraform.key $script_dir/terraform.key.pub
+ssh-keygen -t rsa -N "" -f $script_dir/terraform.key
+
+terraform apply $script_dir
+EXIT_STATUS=$?
+
+terraform destroy -force $script_dir
+DESTROY_STATUS=$?
+
+if [ $DESTROY_STATUS -ne "0" ]; then
+	echo "Test infrastructure was not properly destroyed!"
+	# Notify slack
+fi
+
+exit $EXIT_STATUS


### PR DESCRIPTION
Adds a terraform configuration to provision an EC2 instance to run integration tests on.

- `test/integration/run-integration-test.sh` to provision the AWS infrastructure and run tests
- Requires AWS credentials in the environment with permissions to create ec2 instances, security groups, and key pairs.