### PR TITLE
LDOP-87 Updated certbot image used in the ldop certbot command to lia…

### DIFF
--- a/cmd/certbot
+++ b/cmd/certbot
@@ -208,7 +208,7 @@ gen_letsencrypt_certs() {
         -p 80:80 \
         -p 443:443 \
         -v registry_certs:/etc/letsencrypt \
-        liatrio/certbot:0.0.1 \
+        liatrio/ldop-certbot:0.0.1 \
         certonly --standalone -d ${DOMAIN_NAME} --text --non-interactive --register-unsafely-without-email --agree-tos
 
     if [ -n "${SERVICE_NAME}" ]; then

--- a/cmd/certbot
+++ b/cmd/certbot
@@ -208,7 +208,7 @@ gen_letsencrypt_certs() {
         -p 80:80 \
         -p 443:443 \
         -v registry_certs:/etc/letsencrypt \
-        accenture/certbot:0.0.1 \
+        liatrio/certbot:0.0.1 \
         certonly --standalone -d ${DOMAIN_NAME} --text --non-interactive --register-unsafely-without-email --agree-tos
 
     if [ -n "${SERVICE_NAME}" ]; then


### PR DESCRIPTION
…trio certbot image.

Changed the certbot image dependency to use a Liatrio certbot image. This allows us to have a pinned version separate from Accenture that we can edit as we need. 

No functional changes made.