### PR TITLE
LDOP-131 Renamed ADOPFILEOPTS to LDOPFILEOPTS

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -111,7 +111,7 @@ prep_env() {
         echo "Extension not found: $ext. Exiting."
         exit 1 
       else
-        export ADOPFILEOPTS="${ADOPFILEOPTS} -f ${ext_path}"
+        export LDOPFILEOPTS="${LDOPFILEOPTS} -f ${ext_path}"
       fi
 
       # Add extension sensu client subscription


### PR DESCRIPTION
This was missed when we merged june-demo into master and is causing extensions to not load.