### PR TITLE
Removed obsolete without load flags from test script

### DIFF
--- a/cmd/test
+++ b/cmd/test
@@ -301,11 +301,11 @@ start_with_test_volumes() {
   if [ "$1" = false ]
   then
     echo " Running /ldop compose init --without-load --without-pull"
-    ${CONF_DIR}/ldop compose -v test_local init --without-load --without-pull
+    ${CONF_DIR}/ldop compose -v test_local init --without-pull
   else
     echo "...-w flag specified; omitting without-pull..."
     echo " Running /ldop compose init --without-load"
-    ${CONF_DIR}/ldop compose -v test_local init --without-load
+    ${CONF_DIR}/ldop compose -v test_local init
   fi
   echo '##########################################################'
 }


### PR DESCRIPTION
Removed --without-load from test script. This flag was previously used to stop the jenkins load job from automatically running but the job no longer exists so the flag is obsolete.