### PR TITLE
Updated docker-compose to reflect new version of jenkins image that a…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,7 +281,7 @@ services:
   jenkins:
     container_name: jenkins
     restart: always
-    image: liatrio/ldop-jenkins:2.1.5
+    image: liatrio/ldop-jenkins:2.1.7
     build: submodules/ldop-jenkins
     depends_on:
       - "elasticsearch"


### PR DESCRIPTION
Update the version of Jenkins container to match the new version which allows Jenkins to access docker socket on non-mac hosts.