### PR TITLE
Ldop 189 fix selenium url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   proxy:
     container_name: proxy
     restart: always
-    image: liatrio/ldop-nginx:0.4.0
+    image: liatrio/ldop-nginx:0.4.2
     build: submodules/ldop-nginx
     depends_on:
       - "elasticsearch"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   proxy:
     container_name: proxy
     restart: always
-    image: liatrio/ldop-nginx:0.4.2
+    image: liatrio/ldop-nginx:0.4.3
     build: submodules/ldop-nginx
     depends_on:
       - "elasticsearch"

--- a/swarm-compose.yml
+++ b/swarm-compose.yml
@@ -67,7 +67,7 @@ services:
       - "5601:5601"
 
   proxy:
-    image: liatrio/ldop-nginx:0.4.0
+    image: liatrio/ldop-nginx:0.4.2
     depends_on:
       - "elasticsearch"
       - "logstash"

--- a/swarm-compose.yml
+++ b/swarm-compose.yml
@@ -108,7 +108,7 @@ services:
           - node.role == manager
 
   proxy:
-    image: liatrio/ldop-nginx:0.4.2
+    image: liatrio/ldop-nginx:0.4.3
     depends_on:
       - "elasticsearch"
       - "logstash"


### PR DESCRIPTION
With the Selenium URL fixed inside of the Nginx container, the new image can be used in the master branch. This image allows the Selenium container to be navigated to locally, and on the swarm.