### PR TITLE
Ldop 190 jenkins swarm slave

### DIFF
--- a/cmd/swarm
+++ b/cmd/swarm
@@ -143,7 +143,7 @@ init() {
 	echo "* Pulling down the Docker images may take a moment..."
 	until [[ $(curl -k -I -s -u ${INITIAL_ADMIN_USER}:${INITIAL_ADMIN_PASSWORD_PLAIN} ${PROTO}://${TARGET_HOST}/|head -n 1|cut -d$' ' -f2) == 200 ]]; do pretty_sleep 5 LDOP Swarm; done
   #Have sensu container copy the extension cheks into base checks volume
-	docker run  -v "${PROJECT_NAME}_sensu_server_check:/sensu" -v "${PROJECT_NAME}_sensu_server_check_ext:/sensu_ext" busybox sh -c "cp /sensu_ext/. /sensu"
+	docker run  -v "${PROJECT_NAME}_sensu_server_check:/sensu" -v "${PROJECT_NAME}_sensu_server_check_ext:/sensu_ext" busybox sh -c "cp -r /sensu_ext/. /sensu/"
  
 	for ext in ${EXTENSIONS}; do
           integrations_dir="${CLI_DIR}/extensions/$ext/integrations"

--- a/cmd/swarm
+++ b/cmd/swarm
@@ -145,6 +145,8 @@ init() {
   #Have sensu container copy the extension cheks into base checks volume
 	docker run  -v "${PROJECT_NAME}_sensu_server_check:/sensu" -v "${PROJECT_NAME}_sensu_server_check_ext:/sensu_ext" busybox sh -c "cp -r /sensu_ext/. /sensu/"
  
+  docker service update --force ${PROJECT_NAME}_sensu-server
+
 	for ext in ${EXTENSIONS}; do
           integrations_dir="${CLI_DIR}/extensions/$ext/integrations"
           proxy_integrations_dir="${CLI_DIR}/extensions/$ext/integrations/proxy"

--- a/cmd/swarm
+++ b/cmd/swarm
@@ -101,6 +101,8 @@ init() {
 	# Launches a busybox to mount volumes to simplify the process of adding extensions. The mounted volumes are forced to exist, and the needed directories are created. This action is idempotent.
 	export CONTAINER_ID=$(docker run -v "${PROJECT_NAME}_nginx_config:/nginx" -v "${PROJECT_NAME}_nginx_releasenote:/nginx_release" -v "${PROJECT_NAME}_sensu_server_check:/sensu" busybox sh -c "mkdir -p /nginx/sites-enabled/service-extension; mkdir -p /nginx_release/img;" && docker ps -l -q)
 
+  docker cp $(pwd)/submodules/ldop-sensu/resources/check.d/. ${CONTAINER_ID}:/sensu/
+   
 	# Iterate across all of our listed extensions and adds the required information to Nginx and Sensu. Launches the extension into the swarm.
 	for ext in ${EXTENSIONS}; do
           integrations_dir="${CLI_DIR}/extensions/$ext/integrations"

--- a/cmd/swarm
+++ b/cmd/swarm
@@ -99,14 +99,14 @@ init() {
   set -e
 
 	# Launches a busybox to mount volumes to simplify the process of adding extensions. The mounted volumes are forced to exist, and the needed directories are created. This action is idempotent.
-	export CONTAINER_ID=$(docker run -v "${PROJECT_NAME}_nginx_config:/nginx" -v "${PROJECT_NAME}_nginx_releasenote:/nginx_release" -v "${PROJECT_NAME}_sensu_server_check:/sensu" busybox sh -c "mkdir -p /nginx/sites-enabled/service-extension; mkdir -p /nginx_release/img;" && docker ps -l -q)
+	export CONTAINER_ID=$(docker run -v "${PROJECT_NAME}_nginx_config:/nginx" -v "${PROJECT_NAME}_nginx_releasenote:/nginx_release" -v "${PROJECT_NAME}_sensu_server_check_ext:/sensu_ext" busybox sh -c "mkdir -p /nginx/sites-enabled/service-extension; mkdir -p /nginx_release/img;" && docker ps -l -q)
 
   #pull ldop submodules for sensu checks
   #git submodule update --init --recursive
   #git pull --recurse-submodules
 
   #copy original sensu checks into sensu volume
-  docker cp $(pwd)/submodules/ldop-sensu/resources/check.d/. ${CONTAINER_ID}:/sensu/
+  #docker cp $(pwd)/submodules/ldop-sensu/resources/check.d/. ${CONTAINER_ID}:/sensu/
    
 	# Iterate across all of our listed extensions and adds the required information to Nginx and Sensu. Launches the extension into the swarm.
 	for ext in ${EXTENSIONS}; do
@@ -125,7 +125,7 @@ init() {
               # Add Sensu checks
               if [ -d "${integrations_dir}/sensu/check.d" ]; then
                   echo "  * Adding sensu integration."
-                  docker cp ${integrations_dir}/sensu/check.d/. ${CONTAINER_ID}:/sensu/
+                  docker cp ${integrations_dir}/sensu/check.d/. ${CONTAINER_ID}:/sensu_ext/
                   # Add extension sensu client subscription
                   export SENSU_CLIENT_SUBSCRIPTIONS="${SENSU_CLIENT_SUBSCRIPTIONS},$ext"
               fi
@@ -137,11 +137,14 @@ init() {
 	# Launches LDOP into the swarm.
 	docker stack deploy -c swarm-compose.yml ldop
 
+
 	# Wait for Nginx to come up before proceeding
 	echo "* Waiting for the LDOP Swarm to become available"
 	echo "* Pulling down the Docker images may take a moment..."
 	until [[ $(curl -k -I -s -u ${INITIAL_ADMIN_USER}:${INITIAL_ADMIN_PASSWORD_PLAIN} ${PROTO}://${TARGET_HOST}/|head -n 1|cut -d$' ' -f2) == 200 ]]; do pretty_sleep 5 LDOP Swarm; done
-
+  #Have sensu container copy the extension cheks into base checks volume
+	docker run  -v "${PROJECT_NAME}_sensu_server_check:/sensu" -v "${PROJECT_NAME}_sensu_server_check_ext:/sensu_ext" busybox sh -c "cp /sensu_ext/. /sensu"
+ 
 	for ext in ${EXTENSIONS}; do
           integrations_dir="${CLI_DIR}/extensions/$ext/integrations"
           proxy_integrations_dir="${CLI_DIR}/extensions/$ext/integrations/proxy"

--- a/cmd/swarm
+++ b/cmd/swarm
@@ -101,6 +101,11 @@ init() {
 	# Launches a busybox to mount volumes to simplify the process of adding extensions. The mounted volumes are forced to exist, and the needed directories are created. This action is idempotent.
 	export CONTAINER_ID=$(docker run -v "${PROJECT_NAME}_nginx_config:/nginx" -v "${PROJECT_NAME}_nginx_releasenote:/nginx_release" -v "${PROJECT_NAME}_sensu_server_check:/sensu" busybox sh -c "mkdir -p /nginx/sites-enabled/service-extension; mkdir -p /nginx_release/img;" && docker ps -l -q)
 
+  #pull ldop submodules for sensu checks
+  git submodule update --init --recursive
+  git pull --recurse-submodules
+
+  #copy original sensu checks into sensu volume
   docker cp $(pwd)/submodules/ldop-sensu/resources/check.d/. ${CONTAINER_ID}:/sensu/
    
 	# Iterate across all of our listed extensions and adds the required information to Nginx and Sensu. Launches the extension into the swarm.

--- a/cmd/swarm
+++ b/cmd/swarm
@@ -121,6 +121,8 @@ init() {
               if [ -d "${integrations_dir}/sensu/check.d" ]; then
                   echo "  * Adding sensu integration."
                   docker cp ${integrations_dir}/sensu/check.d/. ${CONTAINER_ID}:/sensu/
+                  # Add extension sensu client subscription
+                  export SENSU_CLIENT_SUBSCRIPTIONS="${SENSU_CLIENT_SUBSCRIPTIONS},$ext"
               fi
 
               docker stack deploy -c ${CLI_DIR}/extensions/$ext/swarm-compose.yml ldop

--- a/cmd/swarm
+++ b/cmd/swarm
@@ -102,8 +102,8 @@ init() {
 	export CONTAINER_ID=$(docker run -v "${PROJECT_NAME}_nginx_config:/nginx" -v "${PROJECT_NAME}_nginx_releasenote:/nginx_release" -v "${PROJECT_NAME}_sensu_server_check:/sensu" busybox sh -c "mkdir -p /nginx/sites-enabled/service-extension; mkdir -p /nginx_release/img;" && docker ps -l -q)
 
   #pull ldop submodules for sensu checks
-  git submodule update --init --recursive
-  git pull --recurse-submodules
+  #git submodule update --init --recursive
+  #git pull --recurse-submodules
 
   #copy original sensu checks into sensu volume
   docker cp $(pwd)/submodules/ldop-sensu/resources/check.d/. ${CONTAINER_ID}:/sensu/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,7 +281,7 @@ services:
   jenkins:
     container_name: jenkins
     restart: always
-    image: liatrio/ldop-jenkins:2.1.7
+    image: liatrio/ldop-jenkins:2.1.10
     build: submodules/ldop-jenkins
     depends_on:
       - "elasticsearch"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,7 +281,7 @@ services:
   jenkins:
     container_name: jenkins
     restart: always
-    image: liatrio/ldop-jenkins:2.1.10
+    image: huntermayers/ldop-jenkins:2.1.10
     build: submodules/ldop-jenkins
     depends_on:
       - "elasticsearch"
@@ -343,7 +343,7 @@ services:
   jenkins-slave:
     container_name: jenkins-slave
     restart: always
-    image: liatrio/ldop-jenkins-slave:0.1.4
+    image: huntermayers/ldop-jenkins-slave:0.1.5
     build: submodules/ldop-jenkins-slave
     depends_on:
       - "elasticsearch"
@@ -356,6 +356,49 @@ services:
       SLAVE_EXECUTORS: ${SLAVE_EXECUTORS}
       INITIAL_ADMIN_USER: ${INITIAL_ADMIN_USER}
       INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD_PLAIN}
+      LDAP_SERVER: "${LDAP_SERVER}"
+      LDAP_ROOTDN: "${LDAP_FULL_DOMAIN}"
+      LDAP_USER_SEARCH_BASE: "${LDAP_USER_BASE_DN}"
+      LDAP_USER_SEARCH: "${LDAP_USER_SEARCH}"
+      LDAP_GROUP_SEARCH_BASE: "${LDAP_GROUP_BASE_DN}"
+      LDAP_GROUP_SEARCH_FILTER: ""
+      LDAP_GROUP_MEMBERSHIP_FILTER: ""
+      LDAP_MANAGER_DN: "${LDAP_MANAGER_DN}"
+      LDAP_MANAGER_PASSWORD: ${LDAP_PWD}
+      LDAP_INHIBIT_INFER_ROOTDN: "false"
+      LDAP_DISABLE_MAIL_ADDRESS_RESOLVER: "false"
+      LDAP_DISPLAY_NAME_ATTRIBUTE_NAME: "displayName"
+      LDAP_MAIL_ADDRESS_ATTRIBUTE_NAME: "mail"
+      LDAP_GROUP_NAME_ADMIN: "${LDAP_GROUP_NAME_ADMIN}"
+      INITIAL_ADMIN_USER: ${INITIAL_ADMIN_USER}
+      INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD_PLAIN}
+      GERRIT_HOST_NAME: "gerrit"
+      GERRIT_FRONT_END_URL: "http://gerrit:8080/gerrit"
+      GERRIT_JENKINS_USERNAME: "${GERRIT_JENKINS_USERNAME}"
+      GERRIT_JENKINS_PASSWORD: ${PASSWORD_JENKINS}
+      SONAR_SERVER_URL: "http://sonar:9000/sonar/"
+      SONAR_ACCOUNT_LOGIN: ${SONAR_ACCOUNT_LOGIN}
+      SONAR_ACCOUNT_PASSWORD: ${PASSWORD_JENKINS}
+      SONAR_DB_URL: "jdbc:mysql://sonar-mysql:3306/sonar?useUnicode=true&amp;characterEncoding=utf8"
+      SONAR_DB_LOGIN: ${SONAR_DB_LOGIN}
+      SONAR_DB_PASSWORD: ${SONAR_DB_PASSWORD}
+      SONAR_PLUGIN_VERSION: ""
+      SONAR_ADDITIONAL_PROPS: ""
+      SONAR_RUNNER_VERSION: "2.4"
+      ANT_VERSION: "1.9.4"
+      MAVEN_VERSION: "3.0.5"
+      NODEJS_VERSION: "6.9.4"
+      NODEJS_GLOBAL_PACKAGES: "grunt-cli@~0.1.13 bower@~1.3.12 plato@~1.2.1"
+      NODEJS_PACKAGES_REFRESH_HOURS: "72"
+      GIT_GLOBAL_CONFIG_NAME: "LDOP Jenkins"
+      GROOVY_VERSION: "2.4.8"
+      GIT_GLOBAL_CONFIG_EMAIL: "jenkins@${LDAP_DOMAIN}"
+      DOCKER_TLS_VERIFY: ${DOCKER_TLS_VERIFY}
+      DOCKER_HOST: ${DOCKER_HOST}
+      DOCKER_CLIENT_CERT_PATH: ${DOCKER_CLIENT_CERT_PATH}
+      DOCKER_NETWORK_NAME: ${CUSTOM_NETWORK_NAME}
+      CARTRIDGE_SOURCES: ${CARTRIDGE_SOURCES}
+      LDOP_NETWORK_NAME: ${CUSTOM_NETWORK_NAME}
 
   selenium-hub:
     container_name: selenium-hub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -343,7 +343,7 @@ services:
   jenkins-slave:
     container_name: jenkins-slave
     restart: always
-    image: liatrio/ldop-jenkins-slave:0.1.4
+    image: liatrio/ldop-jenkins-slave:0.1.5
     build: submodules/ldop-jenkins-slave
     depends_on:
       - "elasticsearch"
@@ -356,6 +356,49 @@ services:
       SLAVE_EXECUTORS: ${SLAVE_EXECUTORS}
       INITIAL_ADMIN_USER: ${INITIAL_ADMIN_USER}
       INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD_PLAIN}
+      LDAP_SERVER: "${LDAP_SERVER}"
+      LDAP_ROOTDN: "${LDAP_FULL_DOMAIN}"
+      LDAP_USER_SEARCH_BASE: "${LDAP_USER_BASE_DN}"
+      LDAP_USER_SEARCH: "${LDAP_USER_SEARCH}"
+      LDAP_GROUP_SEARCH_BASE: "${LDAP_GROUP_BASE_DN}"
+      LDAP_GROUP_SEARCH_FILTER: ""
+      LDAP_GROUP_MEMBERSHIP_FILTER: ""
+      LDAP_MANAGER_DN: "${LDAP_MANAGER_DN}"
+      LDAP_MANAGER_PASSWORD: ${LDAP_PWD}
+      LDAP_INHIBIT_INFER_ROOTDN: "false"
+      LDAP_DISABLE_MAIL_ADDRESS_RESOLVER: "false"
+      LDAP_DISPLAY_NAME_ATTRIBUTE_NAME: "displayName"
+      LDAP_MAIL_ADDRESS_ATTRIBUTE_NAME: "mail"
+      LDAP_GROUP_NAME_ADMIN: "${LDAP_GROUP_NAME_ADMIN}"
+      INITIAL_ADMIN_USER: ${INITIAL_ADMIN_USER}
+      INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD_PLAIN}
+      GERRIT_HOST_NAME: "gerrit"
+      GERRIT_FRONT_END_URL: "http://gerrit:8080/gerrit"
+      GERRIT_JENKINS_USERNAME: "${GERRIT_JENKINS_USERNAME}"
+      GERRIT_JENKINS_PASSWORD: ${PASSWORD_JENKINS}
+      SONAR_SERVER_URL: "http://sonar:9000/sonar/"
+      SONAR_ACCOUNT_LOGIN: ${SONAR_ACCOUNT_LOGIN}
+      SONAR_ACCOUNT_PASSWORD: ${PASSWORD_JENKINS}
+      SONAR_DB_URL: "jdbc:mysql://sonar-mysql:3306/sonar?useUnicode=true&amp;characterEncoding=utf8"
+      SONAR_DB_LOGIN: ${SONAR_DB_LOGIN}
+      SONAR_DB_PASSWORD: ${SONAR_DB_PASSWORD}
+      SONAR_PLUGIN_VERSION: ""
+      SONAR_ADDITIONAL_PROPS: ""
+      SONAR_RUNNER_VERSION: "2.4"
+      ANT_VERSION: "1.9.4"
+      MAVEN_VERSION: "3.0.5"
+      NODEJS_VERSION: "6.9.4"
+      NODEJS_GLOBAL_PACKAGES: "grunt-cli@~0.1.13 bower@~1.3.12 plato@~1.2.1"
+      NODEJS_PACKAGES_REFRESH_HOURS: "72"
+      GIT_GLOBAL_CONFIG_NAME: "LDOP Jenkins"
+      GROOVY_VERSION: "2.4.8"
+      GIT_GLOBAL_CONFIG_EMAIL: "jenkins@${LDAP_DOMAIN}"
+      DOCKER_TLS_VERIFY: ${DOCKER_TLS_VERIFY}
+      DOCKER_HOST: ${DOCKER_HOST}
+      DOCKER_CLIENT_CERT_PATH: ${DOCKER_CLIENT_CERT_PATH}
+      DOCKER_NETWORK_NAME: ${CUSTOM_NETWORK_NAME}
+      CARTRIDGE_SOURCES: ${CARTRIDGE_SOURCES}
+      LDOP_NETWORK_NAME: ${CUSTOM_NETWORK_NAME}
 
   selenium-hub:
     container_name: selenium-hub

--- a/swarm-compose.yml
+++ b/swarm-compose.yml
@@ -529,7 +529,7 @@ services:
           - node.role == manager
 
   jenkins:
-    image: huntermayers/ldop-jenkins:2.1.10
+    image: liatrio/ldop-jenkins:2.1.10
     depends_on:
       - "elasticsearch"
       - "logstash"
@@ -603,7 +603,7 @@ services:
           - node.role == worker
 
   jenkins-slave:
-    image: huntermayers/ldop-jenkins-slave:0.1.5
+    image: liatrio/ldop-jenkins-slave:0.1.5
     depends_on:
       - "elasticsearch"
       - "logstash"

--- a/swarm-compose.yml
+++ b/swarm-compose.yml
@@ -500,7 +500,7 @@ services:
           - node.role == manager
 
   jenkins:
-    image: huntermayers/ldop-jenkins:2.1.7
+    image: huntermayers/ldop-jenkins:2.1.10
     depends_on:
       - "elasticsearch"
       - "logstash"

--- a/swarm-compose.yml
+++ b/swarm-compose.yml
@@ -500,7 +500,7 @@ services:
           - node.role == manager
 
   jenkins:
-    image: liatrio/ldop-jenkins:2.1.7
+    image: huntermayers/ldop-jenkins:2.1.7
     depends_on:
       - "elasticsearch"
       - "logstash"
@@ -574,7 +574,7 @@ services:
           - node.role == worker
 
   jenkins-slave:
-    image: liatrio/ldop-jenkins-slave:0.1.4
+    image: huntermayers/ldop-jenkins-slave:0.1.5
     depends_on:
       - "elasticsearch"
       - "logstash"
@@ -585,6 +585,49 @@ services:
       SLAVE_EXECUTORS: ${SLAVE_EXECUTORS}
       INITIAL_ADMIN_USER: ${INITIAL_ADMIN_USER}
       INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD_PLAIN}
+      LDAP_SERVER: "${LDAP_SERVER}"
+      LDAP_ROOTDN: "${LDAP_FULL_DOMAIN}"
+      LDAP_USER_SEARCH_BASE: "${LDAP_USER_BASE_DN}"
+      LDAP_USER_SEARCH: "${LDAP_USER_SEARCH}"
+      LDAP_GROUP_SEARCH_BASE: "${LDAP_GROUP_BASE_DN}"
+      LDAP_GROUP_SEARCH_FILTER: ""
+      LDAP_GROUP_MEMBERSHIP_FILTER: ""
+      LDAP_MANAGER_DN: "${LDAP_MANAGER_DN}"
+      LDAP_MANAGER_PASSWORD: ${LDAP_PWD}
+      LDAP_INHIBIT_INFER_ROOTDN: "false"
+      LDAP_DISABLE_MAIL_ADDRESS_RESOLVER: "false"
+      LDAP_DISPLAY_NAME_ATTRIBUTE_NAME: "displayName"
+      LDAP_MAIL_ADDRESS_ATTRIBUTE_NAME: "mail"
+      LDAP_GROUP_NAME_ADMIN: "${LDAP_GROUP_NAME_ADMIN}"
+      INITIAL_ADMIN_USER: ${INITIAL_ADMIN_USER}
+      INITIAL_ADMIN_PASSWORD: ${INITIAL_ADMIN_PASSWORD_PLAIN}
+      GERRIT_HOST_NAME: "gerrit"
+      GERRIT_FRONT_END_URL: "http://gerrit:8080/gerrit"
+      GERRIT_JENKINS_USERNAME: "${GERRIT_JENKINS_USERNAME}"
+      GERRIT_JENKINS_PASSWORD: ${PASSWORD_JENKINS}
+      SONAR_SERVER_URL: "http://sonar:9000/sonar/"
+      SONAR_ACCOUNT_LOGIN: ${SONAR_ACCOUNT_LOGIN}
+      SONAR_ACCOUNT_PASSWORD: ${PASSWORD_JENKINS}
+      SONAR_DB_URL: "jdbc:mysql://sonar-mysql:3306/sonar?useUnicode=true&amp;characterEncoding=utf8"
+      SONAR_DB_LOGIN: ${SONAR_DB_LOGIN}
+      SONAR_DB_PASSWORD: ${SONAR_DB_PASSWORD}
+      SONAR_PLUGIN_VERSION: ""
+      SONAR_ADDITIONAL_PROPS: ""
+      SONAR_RUNNER_VERSION: "2.4"
+      ANT_VERSION: "1.9.4"
+      MAVEN_VERSION: "3.0.5"
+      NODEJS_VERSION: "6.9.4"
+      NODEJS_GLOBAL_PACKAGES: "grunt-cli@~0.1.13 bower@~1.3.12 plato@~1.2.1"
+      NODEJS_PACKAGES_REFRESH_HOURS: "72"
+      GIT_GLOBAL_CONFIG_NAME: "LDOP Jenkins"
+      GROOVY_VERSION: "2.4.8"
+      GIT_GLOBAL_CONFIG_EMAIL: "jenkins@${LDAP_DOMAIN}"
+      DOCKER_TLS_VERIFY: ${DOCKER_TLS_VERIFY}
+      DOCKER_HOST: ${DOCKER_HOST}
+      DOCKER_CLIENT_CERT_PATH: ${DOCKER_CLIENT_CERT_PATH}
+      DOCKER_NETWORK_NAME: ${CUSTOM_NETWORK_NAME}
+      CARTRIDGE_SOURCES: ${CARTRIDGE_SOURCES}
+      LDOP_NETWORK_NAME: ${CUSTOM_NETWORK_NAME}
     volumes:
       - jenkins_slave_home:/workspace
       - /var/run/docker.sock:/var/run/docker.sock

--- a/swarm-compose.yml
+++ b/swarm-compose.yml
@@ -349,7 +349,7 @@ services:
         constraints:
           - node.role == manager
 
-  sensu-client:
+  sensu-client-services:
     image: liatrio/ldop-sensu:0.3.0
     command: client
     depends_on:
@@ -380,6 +380,35 @@ services:
       placement:
         constraints:
           - node.role == manager
+
+  sensu-client-system:
+    image: liatrio/ldop-sensu:master
+    command: client
+    depends_on:
+      - "elasticsearch"
+      - "logstash"
+      - "kibana"
+    environment:
+      TRANSPORT_NAME: rabbitmq
+      CLIENT_NAME: ${RANDOM}
+      CLIENT_ADDRESS: 127.0.0.1
+      RABBITMQ_HOST: sensu-rabbitmq
+      JENKINS_PREFIX: jenkins
+      CLIENT_SUBSCRIPTIONS: "basic"
+    volumes:
+      - sensu_client_conf:/etc/sensu/conf.d
+    logging:
+      driver: "syslog"
+      options:
+        syslog-address: "udp://${LOGSTASH_HOST}:25826"
+        tag: "sensu-client"
+    deploy:
+      mode: global
+      update_config:
+        parallelism: 1
+        delay: 10s
+      restart_policy:
+        condition: any
 
   sensu-rabbitmq:
     image: rabbitmq:3.5.7-management


### PR DESCRIPTION
This branch:
Fixes the problems with swarm launching sensu(It was overwriting the basic checks with extension checks) 
Points LDOP to the new jenkins image and jenkins-swarm-slave images which are hooked up by default. It does so by adding the swarm slave plugin to jenkins master. The jenkins-swarm-slave container got remade with the correct docker version so that the docker command we have in our current pipelines can be ran through the slave.