### PR TITLE
LDOP-143 Added 30m timeout to integration test

### DIFF
--- a/test/integration/run-integration-test.sh
+++ b/test/integration/run-integration-test.sh
@@ -6,7 +6,7 @@ script_dir=$(dirname $0)
 rm -f $script_dir/terraform.key $script_dir/terraform.key.pub
 ssh-keygen -t rsa -N "" -f $script_dir/terraform.key
 
-terraform apply $script_dir
+timeout 30m terraform apply $script_dir
 EXIT_STATUS=$?
 
 terraform destroy -force $script_dir


### PR DESCRIPTION
Note: the `timeout` command isn't builtin to MacOS so this needs to be run on a gnu/linux machine.