### PR TITLE
LDOP-40 Added Traefik service to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -488,3 +488,13 @@ services:
       REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY: /data
       REGISTRY_HTTP_TLS_CERTIFICATE: /certs/registry/fullchain.pem
       REGISTRY_HTTP_TLS_KEY: /certs/registry/privkey.pem
+
+  traefik:
+    container_name: traefik
+    command: -c /dev/null --web --docker --docker.domain=docker.localhost --logLevel=DEBUG
+    image: traefik
+    ports:
+      - "3000:80"
+      - "8080:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
Traefik will be used to implement blue/green deployments described in [LDOP-205](https://liatrio.atlassian.net/browse/LDOP-205)