### PR TITLE
Ldop 257 updating terraform scripts

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -471,7 +471,7 @@ done
 
 
 if [ $NEW_CERTS = true ]; then
-  rm platform.secrets.sh || :
+  rm -f platform.secrets.sh || :
 fi
 
 shift $(($OPTIND -1))

--- a/cmd/test
+++ b/cmd/test
@@ -25,8 +25,7 @@ help() {
 }
 
 
-activate_help()
-{
+activate_help() {
     echo
     echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} activate [<options>]"
     echo
@@ -36,8 +35,7 @@ activate_help()
     echo
 }
 
-deactivate_help()
-{
+deactivate_help() {
     echo
     echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} deactivate [<options>]"
     echo
@@ -47,8 +45,7 @@ deactivate_help()
     echo
 }
 
-job_help()
-{
+job_help() {
     echo
     echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} job [<options>]"
     echo
@@ -63,8 +60,7 @@ job_help()
     echo
 }
 
-basic_help()
-{
+basic_help() {
     echo
     echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} basic [<options>]"
     echo
@@ -258,18 +254,18 @@ start_with_test_volumes() {
   if [ "$1" = false ]
   then
     echo " Running /ldop compose init --without-pull"
-    ${CONF_DIR}/ldop compose -p testldopdockercompose init --without-pull
+    ${CONF_DIR}/ldop compose -n testldopdockercompose init --without-pull
   else
     echo "...-w flag specified; omitting without-pull..."
     echo " Running /ldop compose init"
-    ${CONF_DIR}/ldop compose -p testldopdockercompose init
+    ${CONF_DIR}/ldop compose -n testldopdockercompose init
   fi
   echo '##########################################################'
 }
 
 stop_and_remove_test_volumes() {
   echo " ...stopping the test and removing volumes..."
-  ${CONF_DIR}/ldop compose -p testldopdockercompose down --volumes
+  ${CONF_DIR}/ldop compose -n testldopdockercompose down --volumes
   echo '##########################################################'
 }
 
@@ -480,8 +476,10 @@ basic() {
   # If LDOP is currently active, stop it.
   pause_and_stop $BASIC_F_FLAG
 
+
   # Start LDOP with temporary volumes prefixed with test_
   start_with_test_volumes $BASIC_W_FLAG
+
 
   # Run Load_Platform and store the result in $RESULT globally
   # test_parameterized_job "Load_Platform"

--- a/test/integration/run-integration-test.sh
+++ b/test/integration/run-integration-test.sh
@@ -6,6 +6,8 @@ script_dir=$(dirname $0)
 rm -f $script_dir/terraform.key $script_dir/terraform.key.pub
 ssh-keygen -t rsa -N "" -f $script_dir/terraform.key
 
+terraform init $script_dir
+
 timeout 30m terraform apply $script_dir
 EXIT_STATUS=$?
 


### PR DESCRIPTION
this update fixes the error introduced by LDOP-257 by switching the -p flag usage to -n (project name) -p is now used for password