### PR TITLE
LDOP-240 Don't expose to Traefik by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -491,10 +491,11 @@ services:
 
   traefik:
     container_name: traefik
-    command: -c /dev/null --web --docker --docker.domain=docker.localhost --logLevel=DEBUG
-    image: traefik
+    command: --web --docker --docker.domain=docker.localhost --logLevel=DEBUG --docker.exposedbydefault=false
+    image: traefik:1.3-alpine
     ports:
       - "3000:80"
       - "8080:8080"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+


### PR DESCRIPTION
Makes it so containers must explicitly enable traefik (`--label "traefik.enable=true"`) to create proxy configuration. This will prevent Traefik for adding implicit configuration for containers we don't want going through Traefik.

Also pinned the Traefik image.