### PR TITLE
LDOP-276-refactor-username-password-naming-flags

### DIFF
--- a/cmd/compose
+++ b/cmd/compose
@@ -9,9 +9,7 @@ cmd_desc() {
 cmd_usage() {
     echo "usage: ${CMD_NAME} ${SUB_CMD_NAME} [<options>] <subcommand>"
     echo "Options:"
-    printf "    %-12s   %s\n" "-u <username>" "set the initial admin username"
-    printf "    %-12s   %s\n" "-p <password>" "set the initial admin password"
-    printf "    %-12s   %s\n" "-n <name>" "set the project name for the LDOP stack"
+    printf "    %-12s   %s\n" "-p <name>" "set the project name for the LDOP stack"
     printf "    %-12s   %s\n" "-m <name>" "The name of the Docker Machine to target"
     printf "    %-12s   %s\n" "-f <path>" "Additional override file for Docker Compose, can be specified more than once"
     printf "    %-12s   %s\n" "-F <path>" "File to use for Docker Compose (in place of default), can be specified more than once"
@@ -26,8 +24,8 @@ help() {
     echo
     echo "Available subcommands are:"
     printf "    %-22s   %s\n" "init" "Initialises LDOP"
-    printf "    %-22s   %s\n" "init <--without-pull>" "Initialises LDOP without pulling images"
-    printf "    %-22s   %s\n" "init <--without-pull>" "Initialises LDOP without pulling images"
+    printf "    %-12s   %s\n" "init --username <username>" "set the initial admin username"
+    printf "    %-12s   %s\n" "init --password <password>" "set the initial admin password"
     printf "    %-22s   %s\n" "init <--without-pull>" "Initialises LDOP without pulling images"
     printf "    %-22s   %s\n" "init <--with-stdout>" "Initialises LDOP with logs being sent to stdout as opposed to specified logging driver"
     printf "    %-22s   %s\n" "up" "docker-compose up for LDOP"
@@ -185,6 +183,9 @@ load_extensions () {
 
 }
 
+PROVIDED_USERNAME=false
+PROVIDED_PASSWORD=false
+
 init() {
     while [[ $1 ]]; do
         case "$1" in
@@ -196,6 +197,20 @@ init() {
                 export LOGS="NO"
                 shift
                 ;;
+            --username)
+                shift
+                PROVIDED_USERNAME=true
+                export INITIAL_ADMIN_USER="$1"
+                rm -f platform.secrets.sh || :
+                shift
+                ;;
+            --password)
+                shift
+                PROVIDED_PASSWORD=true
+                export INITIAL_ADMIN_PASSWORD_PLAIN="$1"
+                rm -f platform.secrets.sh || :
+                shift
+                ;;
             *)
                 echo "Unrecognized option: $1"
                 help
@@ -203,6 +218,12 @@ init() {
                 ;;
         esac
     done
+
+    if [ "$PROVIDED_USERNAME" != "$PROVIDED_PASSWORD" ] 
+    then
+      echo "Please provide both a username and password."
+      exit
+    fi
 
     echo '
        ##        ########   #######  ########
@@ -424,10 +445,9 @@ export TOTAL_OVERRIDES=""
 export PULL="YES"
 export MACHINE_NAME=""
 export PROJECT_NAME="ldopdockercompose"
-NEW_CERTS=false
 
 # Parameters
-while getopts "m:f:F:v:l:n:i:u:p:n:" opt; do
+while getopts "m:f:F:v:l:n:i:p:" opt; do
   case $opt in
     m)
       export MACHINE_NAME=${OPTARG}
@@ -450,15 +470,7 @@ while getopts "m:f:F:v:l:n:i:u:p:n:" opt; do
     i)
       export PROXY_IP="${OPTARG}"
       ;;
-    u)
-      export INITIAL_ADMIN_USER="${OPTARG}"
-      NEW_CERTS=true
-      ;;
     p)
-      export INITIAL_ADMIN_PASSWORD_PLAIN="${OPTARG}"
-      NEW_CERTS=true
-      ;;
-    n)
       export PROJECT_NAME="${OPTARG}"
       ;;
     *)
@@ -468,11 +480,6 @@ while getopts "m:f:F:v:l:n:i:u:p:n:" opt; do
       ;;
   esac
 done
-
-
-if [ $NEW_CERTS = true ]; then
-  rm -f platform.secrets.sh || :
-fi
 
 shift $(($OPTIND -1))
 SUBCOMMAND_OPT="${1:-help}"

--- a/cmd/test
+++ b/cmd/test
@@ -254,18 +254,18 @@ start_with_test_volumes() {
   if [ "$1" = false ]
   then
     echo " Running /ldop compose init --without-pull"
-    ${CONF_DIR}/ldop compose -n testldopdockercompose init --without-pull
+    ${CONF_DIR}/ldop compose -p testldopdockercompose init --without-pull
   else
     echo "...-w flag specified; omitting without-pull..."
     echo " Running /ldop compose init"
-    ${CONF_DIR}/ldop compose -n testldopdockercompose init
+    ${CONF_DIR}/ldop compose -p testldopdockercompose init
   fi
   echo '##########################################################'
 }
 
 stop_and_remove_test_volumes() {
   echo " ...stopping the test and removing volumes..."
-  ${CONF_DIR}/ldop compose -n testldopdockercompose down --volumes
+  ${CONF_DIR}/ldop compose -p testldopdockercompose down --volumes
   echo '##########################################################'
 }
 


### PR DESCRIPTION
- changed `-u` and `-p` flags to `init` subcommands `init --username <username> --password <password>`
- updated duplicate `-n` flag to `-p` for project name
- updated `test` script to use newly updated `-p` flag
- updated LDOP jenkins job functionality with respect to the change in username and password setting in other repository (See this PR [ldop-via-jenkins-pull-request](https://github.com/liatrio/ldop-via-jenkins/pull/2))