### PR TITLE
LDOP 290 adding portainer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -503,6 +503,8 @@ services:
     container_name: scope
     image: weaveworks/scope:1.6.1
     privileged: true
+    ports:
+      - "4040:4040"
     labels:
       - "works.weave.role=system"
       - "traefik.enable=true"
@@ -513,3 +515,16 @@ services:
     command:
       - "--probe.docker=true"
 
+  portainer:
+    container_name: portainer
+    image: portainer/portainer:1.14.0
+    ports:
+      - "9000:9000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.backend=portainer"
+      - "traefik.frontend.rule=Host:portainer.localhost"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:rw"
+      - "~/.portainer:/data"
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -499,3 +499,16 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
+  scope:
+    container_name: scope
+    image: weaveworks/scope:1.6.1
+    privileged: true
+    labels:
+      - "works.weave.role=system"
+      - "traefik.enable=true"
+      - "traefik.backend=scope"
+      - "traefik.frontend.rule=Host:scope.localhost"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:rw"
+    command:
+      - "--probe.docker=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -499,22 +499,6 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
-  scope:
-    container_name: scope
-    image: weaveworks/scope:1.6.1
-    privileged: true
-    ports:
-      - "4040:4040"
-    labels:
-      - "works.weave.role=system"
-      - "traefik.enable=true"
-      - "traefik.backend=scope"
-      - "traefik.frontend.rule=Host:scope.localhost"
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:rw"
-    command:
-      - "--probe.docker=true"
-
   portainer:
     container_name: portainer
     image: portainer/portainer:1.14.0
@@ -527,4 +511,3 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:rw"
       - "~/.portainer:/data"
-    


### PR DESCRIPTION
adding portioner to LDOP-docker-compose before updating nginx. This is necessary to avoid nginx integration test failures, as nginx will wait for the service (portioner) to become available. Without this addition portainer will never be available and timeout.